### PR TITLE
Commiting changes to fix Python sdk incompatibility for PyXB-X library to support Python 3.12 version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce Python SDK
 
+==Version 12.37.1 (v12.37.1)(August 28, 2024)
+* Change: [cnpAPI v12.37.1] Added change to upgrade to a newer version of PyXB-X library which supports Python 3.12
+
 ==Version 12.37.0 (v12.37.0)(July 10, 2024)
 * Change: [cnpAPI v12.37] New existing 'postCheckoutRedirectUrl' with min length '1' and maxlength '200'
 * Change: [cnpAPI v12.37] New enum 'provider' is added with value 'AFFIRM'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Vantiv eCommerce Python SDK 12.37.0!
+Vantiv eCommerce Python SDK 12.37.1!
 ====================================
 .. toctree::
    :maxdepth: 2

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ if sys.version_info[:2] < (3, 8):
 
 setup(
     name='VantiveCommerceSDK',
-    version='12.37.0',
+    version='12.37.1',
     description='Vantiv eCommerce Python SDK',
     author='Vantiv eCommerce',
     author_email='SDKSupport@vantiv.com',
     url='https://developer.vantiv.com/community/ecommerce',
     packages=['vantivsdk', 'scripts'],
     install_requires=[
-        'PyXB-X==1.2.6.1',
+        'PyXB-X>=1.2.6.1',
         'paramiko>=1.14.0',
         'requests>=2.13.0',
         'six>=1.10.0',

--- a/vantivsdk/version.py
+++ b/vantivsdk/version.py
@@ -25,4 +25,4 @@
 # XML Version
 VERSION = u'12.37'
 # SDK release
-RELEASE = u'12.37.0'
+RELEASE = u'12.37.1'


### PR DESCRIPTION
Updated Python SDK version to 12.37.1
Changed setup.py. Updated PyXB-X ==1.2.6.1 to PyXB-X >= 1.2.6.1 for Python 3.12 compatibility